### PR TITLE
Fix animations

### DIFF
--- a/MMM-WS281X-Server.js
+++ b/MMM-WS281X-Server.js
@@ -1,7 +1,7 @@
 Module.register('MMM-WS281X-Server',{
 
     defaults: {
-        hostname: 'localhost',
+        hostname: '127.0.0.1',
         port: 9999,
         ledOnStart: false,
         ledOnStartEffect: 'start',

--- a/effects/alert.txt
+++ b/effects/alert.txt
@@ -1,6 +1,3 @@
-setup 1,24,0,0,255,18
-init
-
 do
     blink 1,FFFFFF,000000,100,4,1,24
     render

--- a/effects/alert.txt
+++ b/effects/alert.txt
@@ -1,5 +1,5 @@
 do
-    blink 1,FFFFFF,000000,100,4,1,24
+    blink 1,FFFFFF,000000,100,4,1
     render
     delay 500
 loop 2

--- a/effects/alert.txt
+++ b/effects/alert.txt
@@ -5,6 +5,5 @@ do
 loop 2
 
 fill 1,000000
-brightness 1,0
 render
 reset

--- a/effects/blink.txt
+++ b/effects/blink.txt
@@ -1,5 +1,3 @@
-setup 1,24,0,0,255,18
-init
 do
     blink 1,ffffff,000000,100,4,1,24
     render

--- a/effects/blink.txt
+++ b/effects/blink.txt
@@ -3,7 +3,7 @@ do
     render
     delay 500
 loop 4
-fill 1,ff000000
-brightness 1,0
+
+fill 1,000000
 render
 reset

--- a/effects/blink.txt
+++ b/effects/blink.txt
@@ -1,5 +1,5 @@
 do
-    blink 1,ffffff,000000,100,4,1,24
+    blink 1,ffffff,000000,100,4,1
     render
     delay 500
 loop 4

--- a/effects/chaser.txt
+++ b/effects/chaser.txt
@@ -1,6 +1,3 @@
-setup 1,24,0,0,255,18
-init
-
 fill 1,000000
 
 render

--- a/effects/chaser.txt
+++ b/effects/chaser.txt
@@ -1,9 +1,8 @@
 fill 1,000000
-
 render
+
 chaser 1,20,0000FF,1,24
 
 fill 1,000000
-brightness 1,0
 render
 reset

--- a/effects/colorchange.txt
+++ b/effects/colorchange.txt
@@ -1,8 +1,10 @@
+fill 1,AA55CC
+render
+
 do
     color_change 1,0,255,20000
 loop 5
 
 fill 1,000000
-brightness 1,0
 render
 reset

--- a/effects/colorchange.txt
+++ b/effects/colorchange.txt
@@ -1,6 +1,3 @@
-setup 1,24,0,0,255,18
-init
-
 do
     color_change 1,0,255,20000
 loop 5

--- a/effects/example.txt
+++ b/effects/example.txt
@@ -1,6 +1,8 @@
-#24 WS2812 leds on GPIO 18 (PWM0)
-setup 1,24,0,0,255,18
-init
+# channel 1 uses GPIO 1  (broadcom 18)
+# setup/init handled by node_helper
+# setup 1,24,4,0,255,18
+# init
+
 rainbow
 global_brightness 1,64
 render

--- a/effects/example.txt
+++ b/effects/example.txt
@@ -1,7 +1,3 @@
-# channel 1 uses GPIO 1  (broadcom 18)
-# setup/init handled by node_helper
-# setup 1,24,4,0,255,18
-# init
 
 rainbow
 global_brightness 1,64
@@ -18,4 +14,8 @@ do
        render
        delay 100
     loop 30
-loop
+loop 3
+
+fill 1,000000
+render
+reset

--- a/effects/fade.txt
+++ b/effects/fade.txt
@@ -1,16 +1,11 @@
-# channel 1 uses GPIO 1  (broadcom 18)
-# setup/init handled by node_helper
-# setup 1,24,4,0,255,18
-# init
-
 # use white for fade
 fill 1,FFFFFFFF
-brightness 1,0
+
 do
    fade 1,0,255,10,1
    fade 1,255,0,10,1
 loop 4
 fill 1,FF000000
-brightness 1,0
+
 render
 reset

--- a/effects/fade.txt
+++ b/effects/fade.txt
@@ -1,6 +1,8 @@
 # channel 1 uses GPIO 1  (broadcom 18)
-setup 1,24,4,0,255,18
-init
+# setup/init handled by node_helper
+# setup 1,24,4,0,255,18
+# init
+
 # use white for fade
 fill 1,FFFFFFFF
 brightness 1,0

--- a/effects/flyinout.txt
+++ b/effects/flyinout.txt
@@ -1,6 +1,3 @@
-setup 1,24,0,0,255,18
-init
-
 fill 1,0000FF
 fly_in 1
 fly_out 1,0

--- a/effects/flyinout.txt
+++ b/effects/flyinout.txt
@@ -6,7 +6,7 @@ fill 1,FF0080
 fly_in 1,0
 fly_out 1
 
-fill 1,ff000000
-brightness 1,0
+fill 1,000000
 render
+
 reset

--- a/effects/gradient.txt
+++ b/effects/gradient.txt
@@ -1,8 +1,4 @@
-# channel 1 uses GPIO 1  (broadcom 18)
-# setup/init handled by node_helper
-# setup 1,24,4,0,255,18
-# init
-
+# Set color to black
 fill 1,000000
 
 do

--- a/effects/gradient.txt
+++ b/effects/gradient.txt
@@ -1,6 +1,8 @@
 # channel 1 uses GPIO 1  (broadcom 18)
-setup 1,24,0,0,255,18
-init
+# setup/init handled by node_helper
+# setup 1,24,4,0,255,18
+# init
+
 fill 1,000000
 
 do

--- a/effects/login.txt
+++ b/effects/login.txt
@@ -1,6 +1,7 @@
 # channel 1 uses GPIO 1  (broadcom 18)
-setup 1,24,0,0,255,18
-init
+# setup/init handled by node_helper
+# setup 1,24,4,0,255,18
+# init
 
 # use white for fade
 fill 1,FFFFFF

--- a/effects/login.txt
+++ b/effects/login.txt
@@ -1,12 +1,3 @@
-# channel 1 uses GPIO 1  (broadcom 18)
-# setup/init handled by node_helper
-# setup 1,24,4,0,255,18
-# init
-
-# use white for fade
+# use white for fade, remain on
 fill 1,FFFFFF
-brightness 1,0
-
 fade 1,0,255,10,1
-
-render

--- a/effects/logout.txt
+++ b/effects/logout.txt
@@ -1,6 +1,7 @@
 # channel 1 uses GPIO 1  (broadcom 18)
-setup 1,24,0,0,255,18
-init
+# setup/init handled by node_helper
+# setup 1,24,4,0,255,18
+# init
 
 # use white for fade
 fill 1,FFFFFF

--- a/effects/logout.txt
+++ b/effects/logout.txt
@@ -1,13 +1,5 @@
-# channel 1 uses GPIO 1  (broadcom 18)
-# setup/init handled by node_helper
-# setup 1,24,4,0,255,18
-# init
-
 # use white for fade
 fill 1,FFFFFF
-brightness 1,0
-
 fade 1,255,0,10,1
 
-render
 reset

--- a/effects/progress.txt
+++ b/effects/progress.txt
@@ -1,6 +1,3 @@
-setup 1,24,0,0,255,18
-init
-
 do
     fill 1,FFFFFF
     progress 1,1,50

--- a/effects/progress.txt
+++ b/effects/progress.txt
@@ -4,6 +4,6 @@ do
 loop 4
 
 fill 1,000000
-brightness 1,0
 render
+
 reset

--- a/effects/random.txt
+++ b/effects/random.txt
@@ -1,5 +1,3 @@
-setup 1,24,0,0,255,18
-init
 do
    rotate 1,1,2
    random 1,0,1,RGB

--- a/effects/randomfadeio.txt
+++ b/effects/randomfadeio.txt
@@ -1,6 +1,6 @@
-# Busted. Do not use.
+# Parameters: channel, duration(sec), # changing LEDs, delay_between_fade, stepSize
 fill 1,FFFFFF
-random_fade_in_out 1,60,3,10,15,1,100
+random_fade_in_out 1,30,10,10,20
 fill 1,000000
 
 render

--- a/effects/randomfadeio.txt
+++ b/effects/randomfadeio.txt
@@ -1,8 +1,7 @@
+# Busted. Do not use.
 fill 1,FFFFFF
-brightness 1,0
-random_fade_in_out 1,60,12,10,15,800
-
+random_fade_in_out 1,60,3,10,15,1,100
 fill 1,000000
-brightness 1,0
+
 render
 reset

--- a/effects/randomfadeio.txt
+++ b/effects/randomfadeio.txt
@@ -1,6 +1,3 @@
-setup 1,24,0,0,255,18
-init
-
 fill 1,FFFFFF
 brightness 1,0
 random_fade_in_out 1,60,12,10,15,800

--- a/effects/rotate.txt
+++ b/effects/rotate.txt
@@ -1,7 +1,7 @@
 # Busted do not use
 do
-	rotate 1,1,1,FF0000,100
-	rotate 1,1,1,FFFF00,100
+	rotate 1,1,1,FF0000
+	rotate 1,1,1,FFFF00
 loop 12
 
 render

--- a/effects/rotate.txt
+++ b/effects/rotate.txt
@@ -1,6 +1,7 @@
+# Busted do not use
 do
-	rotate 1,1,1,FF0000
-	rotate 1,1,1,FFFF00
+	rotate 1,1,1,FF0000,100
+	rotate 1,1,1,FFFF00,100
 loop 12
 
 render

--- a/effects/rotate.txt
+++ b/effects/rotate.txt
@@ -1,6 +1,3 @@
-setup 1,24,0,0,255,18
-init
-
 do
 	rotate 1,1,1,FF0000
 	rotate 1,1,1,FFFF00

--- a/effects/start.txt
+++ b/effects/start.txt
@@ -1,6 +1,7 @@
 # channel 1 uses GPIO 1  (broadcom 18)
-setup 1,24,0,0,255,18
-init
+# setup/init handled by node_helper
+# setup 1,24,4,0,255,18
+# init
 
 # use white for fade
 fill 1,FFFFFF

--- a/effects/start.txt
+++ b/effects/start.txt
@@ -1,12 +1,5 @@
-# channel 1 uses GPIO 1  (broadcom 18)
-# setup/init handled by node_helper
-# setup 1,24,4,0,255,18
-# init
-
-# use white for fade
+# This will fade in at white and remain on.
 fill 1,FFFFFF
-brightness 1,0
-
 fade 1,0,255,10,1
 
-render
+reset

--- a/node_helper.js
+++ b/node_helper.js
@@ -68,7 +68,7 @@ module.exports = NodeHelper.create({
     
     // Readfile to string relative to execution path
     loadRenderFile: function (filename) {
-        this.ledString = getInit();
+        this.ledString = this.getInit();
         this.ledString += fs.readFileSync(__dirname + '/effects/' + filename + '.txt', 'utf8');
     },
 
@@ -139,7 +139,8 @@ module.exports = NodeHelper.create({
         });
 
         setTimeout(function(){
-            client.end('Bye bye server');
+            // client.end('Bye bye server');
+            client.end();
         },3000);
     },
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -11,6 +11,7 @@ const NodeHelper = require('node_helper');
 const net = require('net');
 const fs = require("fs");
 const bodyParser = require('body-parser');
+const Log = require("logger");
 
 module.exports = NodeHelper.create({
     
@@ -91,16 +92,16 @@ module.exports = NodeHelper.create({
 
         client.on('connect',function(){
             console.log('Client: connection established with ws281x server');
-            /*console.log('---------client details -----------------');
+            console.debug('---------client details -----------------');
 
             var address = client.address();
             var port = address.port;
             var family = address.family;
             var ipaddr = address.address;
             
-            console.log('Client is listening at port: ' + port);
-            console.log('Client IP: ' + ipaddr);
-            console.log('Client is IP4/IP6: ' + family);*/
+            console.debug('Client is listening at port: ' + port);
+            console.debug('Client IP: ' + ipaddr);
+            console.debug('Client is IP4/IP6: ' + family);
         });
 
         client.on('data',function(data){
@@ -253,6 +254,7 @@ module.exports = NodeHelper.create({
     socketNotificationReceived: function (notification, payload) {
         if (notification === 'init') {
             this.config = payload;
+            Log.debug("Config: " + this.config);
             
             if(this.config.ledOnStart) {
                 try {

--- a/node_helper.js
+++ b/node_helper.js
@@ -22,7 +22,7 @@ module.exports = NodeHelper.create({
     
     // This functions sets the color of the whole LED strip
     setStrip: function (color,reset=false) {
-        var initstring = getInit();
+        var initstring = this.getInit();
         var ledstring = 'brightness ' + this.config.channel + ',' + this.config.global_brightness + ';fill ' + this.config.channel + ',' + this.rgbToHex(color) + ';render;';
 
         if (reset) {

--- a/node_helper.js
+++ b/node_helper.js
@@ -22,17 +22,24 @@ module.exports = NodeHelper.create({
     
     // This functions sets the color of the whole LED strip
     setStrip: function (color,reset=false) {
+        var initstring = getInit();
+        var ledstring = 'brightness ' + this.config.channel + ',' + this.config.global_brightness + ';fill ' + this.config.channel + ',' + this.rgbToHex(color) + ';render;';
+
+        if (reset) {
+            ledstring += 'kill_thread;reset;';
+        }
+        this.setLED(initstring+ledstring)
+    },
+
+    // Returns a string to set up the server and initialize the LED string
+    getInit: function () {
         var initstring = 'setup ' + this.config.channel + ',' + this.config.led_count + ',' + this.config.led_type + ',' + this.config.invert + ',' + this.config.global_brightness + ',';
         if(!this.config.spi) {
             initstring += this.config.gpionum + ';init;';
         } else {
             initstring += this.config.spi_dev + ',' + this.config.spi_speed + ',' + this.config.alt_spi_pin + ';init;';
         }
-        var ledstring = 'brightness ' + this.config.channel + ',' + this.config.global_brightness + ';fill ' + this.config.channel + ',' + this.rgbToHex(color) + ';render;';
-        if (reset) {
-            ledstring += 'kill_thread;reset;';
-        }
-        this.setLED(initstring+ledstring)
+        return initstring;
     },
 
     // This function initialises the leds string
@@ -61,7 +68,8 @@ module.exports = NodeHelper.create({
     
     // Readfile to string relative to execution path
     loadRenderFile: function (filename) {
-        this.ledString = fs.readFileSync(__dirname + '/effects/' + filename + '.txt', 'utf8');
+        this.ledString = getInit();
+        this.ledString += fs.readFileSync(__dirname + '/effects/' + filename + '.txt', 'utf8');
     },
 
     // This function renders the current pixels on the connected ws281x-server process

--- a/node_helper.js
+++ b/node_helper.js
@@ -76,13 +76,14 @@ module.exports = NodeHelper.create({
     // This function renders the current pixels on the connected ws281x-server process
     renderLED: function () {
         // Render string for ledstring
-        console.log(String(this.ledString));
+        console.debug(String(this.ledString));
+        console.debug("Connect to: " + this.config.hostname + ", " + this.config.port);
 
         // Start socket connection
         var client = new net.Socket();
         client.connect({
             port: this.config.port,
-            host: this.config.host
+            host: this.config.hostname
         });
 
         client.setEncoding('utf8');
@@ -255,7 +256,7 @@ module.exports = NodeHelper.create({
         if (notification === 'init') {
             this.config = payload;
             Log.debug("Config: " + this.config);
-            
+
             if(this.config.ledOnStart) {
                 try {
                     console.info('[WS281X-Server] Loading LED\'s on start...');


### PR DESCRIPTION
Effect files no longer hard-code the length of the LED string, brightness, or LED type.
Setup commands now use config variables when using effect file names.
I modified each of the animation files to induce consistency in end state (LEDs off).
Removed brightness commands that turned all LEDs off due to brightness persisting through resets.